### PR TITLE
Add tryElementAt method

### DIFF
--- a/lib/src/interable_extensions.dart
+++ b/lib/src/interable_extensions.dart
@@ -6,6 +6,16 @@ final _getNull = () => null;
 
 /// Extension methods for any [Iterable].
 extension IterableExtensions<E> on Iterable<E> {
+  /// Returns the element at the `index` if exists
+  /// or `orElse` if it is out of range.
+  E tryElementAt(int index, {E orElse}) {
+    try {
+      return this.elementAt(index);
+    } catch (e) {
+      return orElse;
+    }
+  }
+
   /// Returns `true` if iterable is `null` or empty.
   bool get isNullOrEmpty {
     return this == null || this.isEmpty;

--- a/test/interable_extensions_test.dart
+++ b/test/interable_extensions_test.dart
@@ -103,6 +103,27 @@ void main() {
       expect(list.isUnorderedEquivalent(other), false);
     });
 
+    group('tryElementAt', () {
+      test('returns the element if exists', () {
+        final list = [1, 2, 3];
+
+        expect(list.tryElementAt(1), 2);
+      });
+
+      test('returns null if index is out of range', () {
+        final list = [1, 2, 3];
+
+        expect(list.tryElementAt(4), null);
+      });
+
+      test('returns fallback value if provided when index is out of range', () {
+        final list = [1, 2, 3];
+
+        expect(list.tryElementAt(4, orElse: 4), 4);
+      });
+    });
+
+
     group('math', () {
       // Sum
       test('sum of int elements property', () {


### PR DESCRIPTION
Hi! 👋 

`elementAt` throws an error if the element at the index doesn't exist - is out of range, so I've created this extension method.

The name is inspired by the `int.tryParse` method but let me know if you have another suggestion for its name. 👍 